### PR TITLE
Improve GATT Serial Transport message handling

### DIFF
--- a/lib/Bean.js
+++ b/lib/Bean.js
@@ -113,33 +113,56 @@ Bean.prototype._onRead = function(gt){
 
 };
 
-Bean.prototype.send = function(cmdBuffer,payloadBuffer,done){
+Bean.prototype.send = function (cmdBuffer, payloadBuffer, done) {
 
-  //size buffer contains size of(cmdBuffer, and payloadBuffer) and a reserved byte set to 0
-  var sizeBuffer = new Buffer(2);
-  sizeBuffer.writeUInt8(cmdBuffer.length + payloadBuffer.length,0);
-  sizeBuffer.writeUInt8(0,1);
+  // Header
+  //  - byte 0: size of cmdBuffer + size of payloadBuffer
+  //  - byte 1: reserved (0)
+  var headerBuffer = new Buffer (2);
+  headerBuffer.writeUInt8 (cmdBuffer.length + payloadBuffer.length, 0);
+  headerBuffer.writeUInt8 (0, 1);
 
-  //GST contains sizeBuffer, cmdBuffer, and payloadBuffer
-  var gstBuffer = Buffer.concat([sizeBuffer,cmdBuffer,payloadBuffer]);
+  // GST: sizeBuffer, cmdBuffer, payloadBuffer, 2 bytes for CRC
+  var gstBuffer = Buffer.concat ([headerBuffer, cmdBuffer, payloadBuffer],
+                                 headerBuffer.length + cmdBuffer.length +
+                                 payloadBuffer.length + 2);
 
-  var crcString = crc.crc16ccitt(gstBuffer);
-  var crc16Buffer = new Buffer(crcString, 'hex');
+  // Message CRC (header, cmd, payload)
+  var msgBuffer = gstBuffer.slice (0, gstBuffer.length - 2);
+  var crcString = crc.crc16ccitt (msgBuffer);
+  var crc16Buffer = new Buffer (crcString, 'hex');
+  gstBuffer[gstBuffer.length-2] = crc16Buffer[1];
+  gstBuffer[gstBuffer.length-1] = crc16Buffer[0];
 
-  //GATT contains sequence header, gstBuffer and crc166
-  var gattBuffer = new Buffer(1 + gstBuffer.length + crc16Buffer.length);
+  // GST complete (gstBufer), slice it to 19-byte chunks -> gstChunk[]
+  var gstChunk = [ ];
+  var gstTail = gstBuffer.slice();
+  while (gstTail.length > 19) {
+    gstChunk.push (gstTail.slice (0, 19));
+    gstTail = gstTail.slice (19);
+  }
+  if (gstTail.length > 0) {
+    gstChunk.push (gstTail);
+  }
 
-  var header = (((this.count++ * 0x20) | 0x80) & 0xff);
-  gattBuffer[0]=header;
+  // GT buffer: sequence header and max. 19 bytes of payload
+  var gattBuffer = new Buffer (20);
 
-  gstBuffer.copy(gattBuffer,1,0); //copy gstBuffer into gatt shifted right 1
+  // Ship the chunks
+  for (var i = 0, max = gstChunk.length; i < max; i++) {
+    if (i == 0) {  // first frame
+      var startBit = 0x80;
+      var msgCount = (this.count++ * 0x20) & 0x60;
+    } else {
+      var startBit = 0x00;
+    }
+    var frameCount = (max - i - 1) & 0x1f;
 
-  //swap 2 crc bytes and add to end of gatt
-  gattBuffer[gattBuffer.length-2]=crc16Buffer[1];
-  gattBuffer[gattBuffer.length-1]=crc16Buffer[0];
-
-  this.writeDataCharacteristic(SERIAL_UUID, BEAN_SERIAL_CHAR_UUID, gattBuffer, done);
-
+    gattBuffer[0] = startBit | msgCount | frameCount;
+    gstChunk[i].copy (gattBuffer, 1, 0); //copy buffer chunk into gatt, offset 1 byte
+    var txBuffer = gattBuffer.slice (0, gstChunk[i].length + 1);
+    this.writeDataCharacteristic (SERIAL_UUID, BEAN_SERIAL_CHAR_UUID, txBuffer, done);
+  }
 };
 
 Bean.prototype.unGate = function(done){


### PR DESCRIPTION
BLE characteristics transport mechanism limits message length to max 20 bytes. This, in combination with GATT Serial Transport message format of BLE Bean, provides sufficient space for max. 15 characters in one single serial message (in an non-fragmented GST buffer, as implemented by the current algorithm). Attempts to transport longer messages not only fail (as expected), but such malformed messages also appear to trigger bugs in the Bean firmware (so that, ultimately, an affected Bean needs to be cold-restarted).

The modification updates algorithm to the desired state: message payload is split to 19-byte chunks, which are then sent in a sequence as defined by the Bean GST protocol specification.

lib/Bean.js - Bean.prototype.send
 - CRC part of GST buffer (gstBuffer)
 - gstBuffer sliced to 19-byte chunks (->gstChunk[])
 - the chunks then sent via SERIAL_UUID BLE characteristics